### PR TITLE
feat: Add deepseek-chat-v3.1 to model list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+.DS_Store
+npm_output.log
+jules-scratch/

--- a/functions/api/models.js
+++ b/functions/api/models.js
@@ -14,7 +14,8 @@ export async function onRequestGet(context) {
     { id: "microsoft/phi-3-mini-128k-instruct:free", name: "Phi-3 Mini 128k (Free)" },
     { id: "qwen/qwen-2-7b-instruct:free", name: "Qwen 2 7B (Free)" },
     { id: "openchat/openchat-7b:free", name: "OpenChat 7B (Free)" },
-    { id: "x-ai/grok-4-fast:free", name: "Grok-4-Fast (Free)" }
+    { id: "x-ai/grok-4-fast:free", name: "Grok-4-Fast (Free)" },
+    { id: "deepseek/deepseek-chat-v3.1:free", name: "DeepSeek Chat v3.1 (Free)" }
   ];
 
   // Probe a model with a tiny completion; mark healthy if we get "OK"


### PR DESCRIPTION
This commit adds the `deepseek/deepseek-chat-v3.1:free` model to the list of available AI models in `functions/api/models.js`. This is in response to other models becoming unavailable.

It also adds a `.gitignore` file to prevent the `node_modules` directory from being committed, which is standard practice for Node.js projects.